### PR TITLE
Fix for ansible 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Available variables are listed below, along with default values (see [defaults/m
 ```yaml
 # By default, module will download last version
 # To specify a version, use this below param
-terragrunt_install_version: X.X.X
+terragrunt_install_version: vX.X.X
 ```
 ### Download information
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@
 ##############################
 # By default, module will download last version
 # To specify a version, use this below param
-# terragrunt_install_version: X.X.X
+# terragrunt_install_version: vX.X.X
 
 ###############################################
 # Download information - Modify only if needed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@
 # Download information - Modify only if needed
 ###############################################
 # Directory where executable will be downloaded before installation
-terragrunt_download_location: /tmp/
+terragrunt_download_location: /tmp
 # Url to terragrunt binarie
 terragrunt_url: "https://github.com/gruntwork-io/terragrunt/releases/download/{{ terragrunt_install_version }}/terragrunt_linux_amd64"
 # Downloaded file name 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,6 +11,7 @@
 
 - name: Move Terragrunt binarie for execution
   copy:
+    remote_src: true
     src: "{{ terragrunt_download_location }}/{{ terragrunt_downloaded_file_name }}"
     dest: "{{ terragrunt_execution_path }}/{{ terragrunt_execution_file_name }}"
     mode: u+x,g+x,o+x


### PR DESCRIPTION
Current master does not work with Ansible 2.7.1 on Ubuntu 18.04.1. Fixed a few things to make it work again.